### PR TITLE
Updated regexp for removing whitespaces between HTML tags

### DIFF
--- a/src/Middleware/MinifyResponse.php
+++ b/src/Middleware/MinifyResponse.php
@@ -21,10 +21,23 @@ class MinifyResponse
         /** @var Response $response */
         $response = $next($request);
 
-        if (!app()->isLocal() and false === is_a($response, StreamedResponse::class)) {
+        if (!app()->isLocal() && $this->isHtml($response)) {
             $response->setContent((new Minifier())->html($response->getContent()));
         }
 
         return $response;
+    }
+
+     /**
+     * Check if the content type header is html.
+     *
+     * @param \Illuminate\Http\Response $response
+     *
+     * @return bool
+     */
+    protected function isHtml($response)
+    {
+        $type = $response->headers->get('Content-Type');
+        return strtolower(strtok($type, ';')) === 'text/html';
     }
 }

--- a/src/Minifier.php
+++ b/src/Minifier.php
@@ -12,7 +12,7 @@ class Minifier
         // Shorten multiple white spaces
         '/\s{2,}/' => ' ',
         // Remove whitespaces between HTML tags
-        '/>\s+</' => '><',
+        '/>\s{2,}</' => '><',
         // Collapse new lines
         '/(\r?\n)/' => '',
     ];


### PR DESCRIPTION
I have problem with two links in a row:

```
$m = new \Nckg\Minify\Minifier();
$result = $m->html('<a href="">link1</a> <a href="">link2</a>');
dd($result); 
```
In browser :
```
link1link2
```